### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,14 @@ DevHub is a cross-functional team that supports the NEAR ecosystem by providing 
 
 ## Individual Workstreams
 
-| Board | Repo | Create Task | Lead | 📸 |
-| ------------ | :---: | :---: | :---: | :---: |
-| [![Developer Tools](https://img.shields.io/badge/🛠️_Developer_Tools-0F52BA?style=for-the-badge)](https://github.com/orgs/near/projects/156) | [near/devtools](https://github.com/near/devtools) | [📝](https://github.com/near/devtools/issues/new/choose) | [@frol](https://github.com/frol) | [![frol](https://github.com/frol.png?size=33)](https://github.com/frol) |
-| [![Developer Relations](https://img.shields.io/badge/🧑‍💻_Developer_Relations-5D3FD3?style=for-the-badge)](https://github.com/orgs/near/projects/117) | [near/devrel](https://github.com/near/devrel) | [📝](https://github.com/near/devrel/issues/new/choose) | [@gagdiez](https://github.com/gagdiez) | [![gagdiez](https://github.com/gagdiez.png?size=33)](https://github.com/gagdiez) |
-| [![Developer Content](https://img.shields.io/badge/📢_Developer_Content-FFBF00?style=for-the-badge)](https://github.com/orgs/NEAR-DevHub/projects/9) | [near-devhub/content](https://github.com/near-devhub/content) | [📝](https://github.com/near-DevHub/content/issues/new/choose) | [@joe-rlo](https://github.com/joe-rlo) | [![joe-rlo](https://github.com/joe-rlo.png?size=33)](https://github.com/joe-rlo) |
-| [![Devhub Products](https://img.shields.io/badge/🚀_Devhub_Products-50C878?style=for-the-badge)](https://github.com/orgs/NEAR-DevHub/projects/4) | [near-devhub/products](https://github.com/near-devhub/products) | [📝](https://github.com/near-DevHub/products/issues/new/choose) | [@ori-near](https://github.com/ori-near) | [![ori-near](https://github.com/ori-near.png?size=33)](https://github.com/ori-near) |
-| [![Partner Support](https://img.shields.io/badge/🤝_Partner_Support-850101?style=for-the-badge)](https://github.com/orgs/NEAR-DevHub/projects/7) | [near-devhub/partner-support](https://github.com/NEAR-DevHub/partner-support) | [📝](https://github.com/NEAR-DevHub/dedicated-support/issues/new/choose) | [@thisisjoshford](https://github.com/thisisjoshford) | [![thisisjoshford](https://github.com/thisisjoshford.png?size=33)](https://github.com/thisisjoshford) |
-| [![Infra Committee](https://img.shields.io/badge/🏗️_Infra_Committee-FF5733?style=for-the-badge)](https://github.com/orgs/NEAR-DevHub/projects/12) | [near-devhub/infra-committee](https://github.com/NEAR-DevHub/Infra-Committee) | [📝](https://github.com/NEAR-DevHub/Infra-Committee/issues/new/choose) | [@trechriron](https://github.com/trechriron) | [![trechriron](https://github.com/trechriron.png?size=33)](https://github.com/trechriron) |
-| [![Operations](https://img.shields.io/badge/⚙️_Operations-000000?style=for-the-badge)](https://github.com/orgs/NEAR-DevHub/projects/8) | [near-devhub/operations](https://github.com/near-devhub/operations) | [📝](https://github.com/NEAR-DevHub/operations/issues/new/choose) | [@ori-near](https://github.com/ori-near) | [![ori-near](https://github.com/ori-near.png?size=33)](https://github.com/ori-near) |
+| Board | Repo | Lead | 📸 |
+| ------------ | :---: | :---: | :---: |
+| [![Developer Tools](https://img.shields.io/badge/🛠️_Developer_Tools-0F52BA?style=for-the-badge)](https://github.com/orgs/near/projects/156) | [near/devtools](https://github.com/near/devtools) | [@frol](https://github.com/frol) | [![frol](https://github.com/frol.png?size=33)](https://github.com/frol) |
+| [![Developer Relations](https://img.shields.io/badge/🧑‍💻_Developer_Relations-5D3FD3?style=for-the-badge)](https://github.com/orgs/near/projects/117) | [near/devrel](https://github.com/near/devrel) | [@gagdiez](https://github.com/gagdiez) | [![gagdiez](https://github.com/gagdiez.png?size=33)](https://github.com/gagdiez) |
+| [![Developer Content](https://img.shields.io/badge/📢_Developer_Content-FFBF00?style=for-the-badge)](https://github.com/orgs/NEAR-DevHub/projects/9) | [near-devhub/content](https://github.com/near-devhub/content) | [@joe-rlo](https://github.com/joe-rlo) | [![joe-rlo](https://github.com/joe-rlo.png?size=33)](https://github.com/joe-rlo) |
+| [![Devhub Products](https://img.shields.io/badge/🚀_Devhub_Products-50C878?style=for-the-badge)](https://github.com/orgs/NEAR-DevHub/projects/4) | [near-devhub/products](https://github.com/near-devhub/products) | [@ori-near](https://github.com/ori-near) | [![ori-near](https://github.com/ori-near.png?size=33)](https://github.com/ori-near) |
+| [![Partner Support](https://img.shields.io/badge/🤝_Partner_Support-850101?style=for-the-badge)](https://github.com/orgs/NEAR-DevHub/projects/7) | [near-devhub/partner-support](https://github.com/NEAR-DevHub/partner-support) | [@thisisjoshford](https://github.com/thisisjoshford) | [![thisisjoshford](https://github.com/thisisjoshford.png?size=33)](https://github.com/thisisjoshford) |
+
 
 ---
 
@@ -68,18 +67,3 @@ DevHub is a cross-functional team that supports the NEAR ecosystem by providing 
 
 - Defining clear technical requirements based on feedback and identifying partners for solutions
 - Providing technical support, including custom solutions and project management, either directly or in collaboration with external API providers
-
-### 🏗️ Infrastructure Committee
-
-> Coordinating infrastructure initiatives across the ecosystem
-
-- Creating Requests For Proposals (RFPs) that detail needs across the ecosystem. Partners, companies, and organizations can submit proposals to fulfill these needs.
-- Review, refine, and vote on submitted proposals.
-- Budget and distribute an envelope of funds determined by the NEAR Foundation.
-- Manage funded project status and review project milestones for payments.
-
-### ⚙️ Operations
-
-> Coordinating general operations for DevHub
-
-- Providing project management and operational services to designated partners (e.g. Infrastructure Committee)


### PR DESCRIPTION
Based on conversations on FRI, we don't believe the create task column was needed. It was removed to simplify. 

Operations is not a needed project or board. Removed.

The Infrastructure Committee board and project will be deleted, and stuff will be moved into Notion.